### PR TITLE
🐛 Fix: 게시글 관련 오류 해결

### DIFF
--- a/src/main/java/com/develop/thankyounext/application/command/entity/gallery/GalleryCommandService.java
+++ b/src/main/java/com/develop/thankyounext/application/command/entity/gallery/GalleryCommandService.java
@@ -2,6 +2,7 @@ package com.develop.thankyounext.application.command.entity.gallery;
 
 import com.develop.thankyounext.domain.dto.base.common.AuthenticationDto;
 import com.develop.thankyounext.domain.dto.gallery.GalleryRequest.RegisterGallery;
+import com.develop.thankyounext.domain.dto.gallery.GalleryRequest.UpdateGallery;
 import com.develop.thankyounext.domain.dto.result.ResultResponse.GalleryResult;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -9,4 +10,6 @@ import java.util.List;
 
 public interface GalleryCommandService {
     GalleryResult registerGallery(AuthenticationDto auth, RegisterGallery request, List<MultipartFile> fileList);
+
+    GalleryResult updateGallery(AuthenticationDto auth, UpdateGallery request, List<MultipartFile> fileList);
 }

--- a/src/main/java/com/develop/thankyounext/application/command/entity/post/PostCommandServiceImpl.java
+++ b/src/main/java/com/develop/thankyounext/application/command/entity/post/PostCommandServiceImpl.java
@@ -139,7 +139,7 @@ public class PostCommandServiceImpl implements PostCommandService {
         imageRepository.deleteAllByPostId(request.postId());
         postTagRepository.deleteAllByPostId(request.postId());
         commentRepository.deleteAllByPostId(request.postId());
-        postRepository.deleteById(currentPost.getId());
+        postRepository.deleteAllById(currentPost.getId());
 
         return postResult;
     }

--- a/src/main/java/com/develop/thankyounext/domain/dto/base/entity/ImageDto.java
+++ b/src/main/java/com/develop/thankyounext/domain/dto/base/entity/ImageDto.java
@@ -1,0 +1,10 @@
+package com.develop.thankyounext.domain.dto.base.entity;
+
+import lombok.Builder;
+
+@Builder
+public record ImageDto(
+    Long id,
+    String url
+) {
+}

--- a/src/main/java/com/develop/thankyounext/domain/dto/base/entity/PostDto.java
+++ b/src/main/java/com/develop/thankyounext/domain/dto/base/entity/PostDto.java
@@ -1,10 +1,11 @@
 package com.develop.thankyounext.domain.dto.base.entity;
 
 import com.develop.thankyounext.domain.dto.base.common.AuditingDto;
-import com.develop.thankyounext.domain.entity.embedded.PostImageList;
 import com.develop.thankyounext.domain.enums.PostEnum;
 import com.develop.thankyounext.domain.enums.SolvedEnum;
 import lombok.Builder;
+
+import java.util.List;
 
 @Builder
 public record PostDto(
@@ -13,7 +14,7 @@ public record PostDto(
         String content,
         PostEnum dType,
         SolvedEnum isSolved,
-        PostImageList imageList,
+        List<ImageDto> imageDtoList,
         AuditingDto auditingDto
 ) {
 }

--- a/src/main/java/com/develop/thankyounext/domain/entity/Gallery.java
+++ b/src/main/java/com/develop/thankyounext/domain/entity/Gallery.java
@@ -28,4 +28,8 @@ public class Gallery extends BaseEntity {
     public void setImageList(GalleryImageList imageList) {
         this.imageList = imageList;
     }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
 }

--- a/src/main/java/com/develop/thankyounext/domain/entity/Image.java
+++ b/src/main/java/com/develop/thankyounext/domain/entity/Image.java
@@ -1,6 +1,5 @@
 package com.develop.thankyounext.domain.entity;
 
-import com.develop.thankyounext.domain.entity.embedded.GalleryImageList;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/develop/thankyounext/domain/entity/embedded/PostImageList.java
+++ b/src/main/java/com/develop/thankyounext/domain/entity/embedded/PostImageList.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.List;
 @Builder
 public class PostImageList {
 
+    @BatchSize(size = 100)
     @Builder.Default
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Image> imageList = new ArrayList<>();

--- a/src/main/java/com/develop/thankyounext/domain/repository/image/ImageQueryDSL.java
+++ b/src/main/java/com/develop/thankyounext/domain/repository/image/ImageQueryDSL.java
@@ -2,4 +2,6 @@ package com.develop.thankyounext.domain.repository.image;
 
 public interface ImageQueryDSL {
     Long deleteAllByPostId(Long postId);
+
+    Long deleteAllByGalleryId(Long galleryId);
 }

--- a/src/main/java/com/develop/thankyounext/domain/repository/image/ImageQueryDSLImpl.java
+++ b/src/main/java/com/develop/thankyounext/domain/repository/image/ImageQueryDSLImpl.java
@@ -20,4 +20,14 @@ public class ImageQueryDSLImpl implements ImageQueryDSL{
                 .where(image.post.id.eq(postId))
                 .execute();
     }
+
+    @Override
+    public Long deleteAllByGalleryId(Long galleryId) {
+        QImage image = QImage.image;
+
+        return jpaQueryFactory
+                .delete(image)
+                .where(image.gallery.id.eq(galleryId))
+                .execute();
+    }
 }

--- a/src/main/java/com/develop/thankyounext/domain/repository/post/PostQueryDSL.java
+++ b/src/main/java/com/develop/thankyounext/domain/repository/post/PostQueryDSL.java
@@ -17,4 +17,6 @@ public interface PostQueryDSL {
     Optional<Post> findByIdWithCommentAndMember(Long postId);
 
     Optional<Post> findByIdWithMember(Long postId);
+
+    Long deleteAllById(Long postId);
 }

--- a/src/main/java/com/develop/thankyounext/domain/repository/post/PostQueryDSLImpl.java
+++ b/src/main/java/com/develop/thankyounext/domain/repository/post/PostQueryDSLImpl.java
@@ -1,9 +1,6 @@
 package com.develop.thankyounext.domain.repository.post;
 
-import com.develop.thankyounext.domain.entity.Post;
-import com.develop.thankyounext.domain.entity.QComment;
-import com.develop.thankyounext.domain.entity.QMember;
-import com.develop.thankyounext.domain.entity.QPost;
+import com.develop.thankyounext.domain.entity.*;
 import com.develop.thankyounext.domain.entity.mapping.QPostTag;
 import com.develop.thankyounext.domain.enums.PostEnum;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -78,6 +75,7 @@ public class PostQueryDSLImpl implements PostQueryDSL {
         QPost post = QPost.post;
         QComment comment = QComment.comment;
         QMember member = QMember.member;
+        QImage image = QImage.image;
 
         Post findPost = jpaQueryFactory
                 .selectFrom(post)
@@ -101,6 +99,16 @@ public class PostQueryDSLImpl implements PostQueryDSL {
                 .fetchOne();
 
         return Optional.ofNullable(findPost);
+    }
+
+    @Override
+    public Long deleteAllById(Long postId) {
+        QPost post = QPost.post;
+
+        return jpaQueryFactory
+                .delete(post)
+                .where(post.id.eq(postId))
+                .execute();
     }
 
     private JPAQuery<Long> createCountQuery(BooleanExpression condition, QPost post) {

--- a/src/main/java/com/develop/thankyounext/global/exception/handler/GalleryHandler.java
+++ b/src/main/java/com/develop/thankyounext/global/exception/handler/GalleryHandler.java
@@ -1,0 +1,10 @@
+package com.develop.thankyounext.global.exception.handler;
+
+import com.develop.thankyounext.global.exception.GeneralException;
+import com.develop.thankyounext.global.payload.code.BaseErrorCode;
+
+public class GalleryHandler extends GeneralException {
+    public GalleryHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/develop/thankyounext/global/payload/code/status/ErrorStatus.java
+++ b/src/main/java/com/develop/thankyounext/global/payload/code/status/ErrorStatus.java
@@ -27,7 +27,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Comment
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404", "해당 댓글을 찾을 수 없습니다."),
-    COMMENT_NOT_AUTHOR_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMENT4031", "해당 댓글의 작성자가 아닙니다.")
+    COMMENT_NOT_AUTHOR_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMENT4031", "해당 댓글의 작성자가 아닙니다."),
+
+    // Gallery
+    GALLERY_NOT_FOUND(HttpStatus.NOT_FOUND, "GALLERY404", "해당 갤러리 게시글을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/develop/thankyounext/infrastructure/converter/GalleryConverter.java
+++ b/src/main/java/com/develop/thankyounext/infrastructure/converter/GalleryConverter.java
@@ -15,6 +15,6 @@ public interface GalleryConverter {
     Gallery toGallery(RegisterGallery registerGallery);
 
     @Mapping(source = "id", target = "galleryId")
-    @Mapping(source = "createdAt", target = "executedAt")
+    @Mapping(source = "createdAt", target = "executedAt", defaultExpression = "java(java.time.LocalDateTime.now())")
     GalleryResult toGalleryResult(Gallery saveGallery);
 }

--- a/src/main/java/com/develop/thankyounext/infrastructure/converter/PostConverter.java
+++ b/src/main/java/com/develop/thankyounext/infrastructure/converter/PostConverter.java
@@ -28,6 +28,7 @@ public interface PostConverter {
     SimplePostDto toSimplePostDto(Post post);
 
     @Mapping(source = "DType", target = "dType")
+    @Mapping(source = "imageList.imageList", target = "imageDtoList")
     @Mapping(source = "createdAt", target = "auditingDto.createdAt")
     @Mapping(source = "createdBy", target = "auditingDto.createdBy")
     @Mapping(source = "modifiedAt", target = "auditingDto.modifiedAt")

--- a/src/main/java/com/develop/thankyounext/presentation/GalleryController.java
+++ b/src/main/java/com/develop/thankyounext/presentation/GalleryController.java
@@ -76,19 +76,20 @@ public class GalleryController {
         return ApiResponseDTO.onSuccess(resultDTO);
     }
 
-    @PatchMapping
+    @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(
             description = "갤러리 제목, 첨부파일 리스트를 받아 수정합니다.",
-            summary = "갤러리 수정 API (개발중)"
+            summary = "갤러리 수정 API"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
     })
     public ApiResponseDTO<GalleryResult> updateGallery(
+            @AuthenticationPrincipal AuthenticationDto auth,
             @RequestPart final UpdateGallery request,
-            @RequestPart final List<MultipartFile> imageList
+            @RequestPart final List<MultipartFile> fileList
     ) {
-        GalleryResult resultDTO = null;
+        GalleryResult resultDTO = galleryCommandService.updateGallery(auth, request, fileList);
         return ApiResponseDTO.onSuccess(resultDTO);
     }
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/ys/26

### 💡 작업동기
- 게시글 단건 조회시 json 파싱에 문제가 있습니다.
- 게시글 단건 조회시 이미지가 불러와지지 않는 오류가 있습니다.
- 게시글 삭제시 중복 삭제로 추정되는 문제가 있습니다.

### 🔑 주요 변경사항
- 멀티 페치조인 문제 해결을 위해 `Image` 엔티티에 `@BatchSize` 속성을 부여했습니다.
- `PostDto`에 Image 엔티티가 아닌 `ImageDto`가 포함되도록 수정했습니다.
- 게시글 중복 삭제 문제 해결을 위해 게시글 삭제를 `Data JPA`가 아닌 `QueryDSL` 쿼리를 사용하도록 수정하였습니다.

### 관련 이슈
- #26 